### PR TITLE
chore: add SessionStart hook for remote skill bootstrap

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ \"$CLAUDE_CODE_REMOTE\" != \"true\" ] && exit 0; [ -d /tmp/claude_ref ] || git clone --depth 1 https://x-access-token:${GH_TOKEN}@github.com/duquesnay/claude-memories.git /tmp/claude_ref >&2; /tmp/claude_ref/scripts/remote-bootstrap.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.json` with a SessionStart hook that bootstraps remote skills

https://claude.ai/code/session_0141CtwxuTCYHpuMG3vauPMD